### PR TITLE
Changes unused Component types from undefined to {}

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,11 +13,11 @@ export interface MDSpinnerProps {
   color4?: string
 }
 
-export default class MDSpinner extends Component<MDSpinnerProps, undefined> {
+export default class MDSpinner extends Component<MDSpinnerProps, {}> {
   /* explicitly empty */
 }
 
 declare namespace ssrBehavior {
   export function getStylesheetString(userAgent?: string): string;
-  export function getStylesheetComponent(userAgent?: string): Component<undefined, undefined>;
+  export function getStylesheetComponent(userAgent?: string): Component<{}, {}>;
 }


### PR DESCRIPTION
I am getting this error in my project:
```
TS2605: JSX element type 'MDSpinner' is not a constructor function for JSX elements.
  Types of property 'setState' are incompatible.
    Type '{ <K extends never>(f: (prevState: undefined, props: MDSpinnerProps) => Pick<undefined, K>, callb...' is not assignable to type '{ <K extends never>(f: (prevState: {}, props: any) => Pick<{}, K>, callback?: (() => any) | undef...'.
      Types of parameters 'f' and 'f' are incompatible.
        Type '(prevState: {}, props: any) => Pick<{}, any>' is not assignable to type '(prevState: undefined, props: MDSpinnerProps) => Pick<undefined, any>'.
          Types of parameters 'prevState' and 'prevState' are incompatible.
            Type 'undefined' is not assignable to type '{}'.
```

Because React defaults the state to {}, which is not undefined.
I'm on 
- `react` 16.6.1
- `@types/react` 15.0.38
- `typescript` 2.3.4

I believe the unused props should be completely removed, per https://github.com/DefinitelyTyped/DefinitelyTyped/pull/17288 on `@types/react`.
Like this:
```
import { Component } from "react";

export interface MDSpinnerProps {
  className?: string,
  userAgent?: string,
  style?: object,
  singleColor?: string,
  size?: number | string,
  duration?: number,
  color1?: string,
  color2?: string,
  color3?: string,
  color4?: string
}

export default class MDSpinner extends Component<MDSpinnerProps> {
  /* explicitly empty */
}

declare namespace ssrBehavior {
  export function getStylesheetString(userAgent?: string): string;
  export function getStylesheetComponent(userAgent?: string): Component;
}
```

But I didn't remove it in case someone is using this with an older version of `@types/react` that doesn't have the default types in React.Component.
